### PR TITLE
docs: fix typos

### DIFF
--- a/Classes/NetworkLoggerPlugin/Configuration.html
+++ b/Classes/NetworkLoggerPlugin/Configuration.html
@@ -389,7 +389,7 @@
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>The designated way to instanciate a Configuration.</p>
+                        <p>The designated way to instantiate a Configuration.</p>
 
                       </div>
                       <div class="declaration">

--- a/Classes/NetworkLoggerPlugin/Configuration/Formatter.html
+++ b/Classes/NetworkLoggerPlugin/Configuration/Formatter.html
@@ -416,7 +416,7 @@
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>The designated way to instanciate a Formatter.</p>
+                        <p>The designated way to instantiate a Formatter.</p>
 
                       </div>
                       <div class="declaration">

--- a/docsets/Moya.docset/Contents/Resources/Documents/Classes/NetworkLoggerPlugin/Configuration.html
+++ b/docsets/Moya.docset/Contents/Resources/Documents/Classes/NetworkLoggerPlugin/Configuration.html
@@ -389,7 +389,7 @@
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>The designated way to instanciate a Configuration.</p>
+                        <p>The designated way to instantiate a Configuration.</p>
 
                       </div>
                       <div class="declaration">

--- a/docsets/Moya.docset/Contents/Resources/Documents/Classes/NetworkLoggerPlugin/Configuration/Formatter.html
+++ b/docsets/Moya.docset/Contents/Resources/Documents/Classes/NetworkLoggerPlugin/Configuration/Formatter.html
@@ -416,7 +416,7 @@
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>The designated way to instanciate a Formatter.</p>
+                        <p>The designated way to instantiate a Formatter.</p>
 
                       </div>
                       <div class="declaration">


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `Classes/NetworkLoggerPlugin/Configuration.html`
- 1 typo in `Classes/NetworkLoggerPlugin/Configuration/Formatter.html`
- 1 typo in `docsets/Moya.docset/Contents/Resources/Documents/Classes/NetworkLoggerPlugin/Configuration.html`
- 1 typo in `docsets/Moya.docset/Contents/Resources/Documents/Classes/NetworkLoggerPlugin/Configuration/Formatter.html`



Ciao! :robot: